### PR TITLE
ensure upper() doesn't increase string length

### DIFF
--- a/interegular/patterns.py
+++ b/interegular/patterns.py
@@ -54,6 +54,15 @@ def _combine_flags(base: REFlags, added: REFlags, removed: REFlags):
     return base
 
 
+def _one_char_upper(char: str) -> str:
+    """Convert char to upper, if multiple chars, return original char"""
+    assert len(char) == 1
+    upper_char = char.upper()
+    if len(upper_char) > 1:
+        return char
+    return upper_char
+
+
 @dataclass(frozen=True)
 class _BasePattern(ABC):
     __slots__ = '_alphabet_cache', '_prefix_cache', '_lengths_cache'
@@ -115,7 +124,7 @@ class _CharGroup(_Repeatable):
 
     def _get_alphabet(self, flags: REFlags) -> Alphabet:
         if flags & REFlags.CASE_INSENSITIVE:
-            relevant = {*map(str.lower, self.chars), *map(str.upper, self.chars)}
+            relevant = {*map(str.lower, self.chars), *map(_one_char_upper, self.chars)}
         else:
             relevant = self.chars
         return Alphabet.from_groups(relevant, {anything_else})
@@ -139,7 +148,7 @@ class _CharGroup(_Repeatable):
         if flags:
             raise Unsupported(flags)
         if insensitive:
-            chars = frozenset({*(c.lower() for c in self.chars), *(c.upper() for c in self.chars)})
+            chars = frozenset({*(c.lower() for c in self.chars), *(_one_char_upper(c) for c in self.chars)})
         else:
             chars = self.chars
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -97,6 +97,14 @@ class SyntaxTestCase(unittest.TestCase):
         self.parse_unsupported("(?u)")
         self.parse_unsupported("(?x)")
 
+    def test_multichar(self):
+        fsm = parse_pattern("(?i:ß)").to_fsm()
+        strings = set([s[0] for s in fsm.strings()])
+        assert fsm.accepts("ß")
+        assert not fsm.accepts("SS")
+        assert "ß" in strings
+        assert "SS" not in strings
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/outlines-dev/outlines/issues/773

# Problem

In `master`, interegular uses `char.upper()`, which can convert one char into two, resulting the set of `accepts()` and `strings()` being inconsistent.

```
 >>> 'ß'.upper()
'SS'
```


`accepts()` and `strings()` inconsistency:
 ```
    def test_multichar(self):
        fsm = parse_pattern("(?i:ß)").to_fsm()
        strings = set([s[0] for s in fsm.strings()])
        assert fsm.accepts("ß")
        assert not fsm.accepts("SS")
        assert "ß" in strings
>       assert "SS" not in strings
E       AssertionError: assert 'SS' not in {'SS', 'ß'}
```

This change ensures if a capitalized character isn't of length 1, the original character is used.

This is consistent with the behavior of `re`:

```
>>> print(re.match(r"(?i:ß)", "ß"))
<re.Match object; span=(0, 1), match='ß'>
>>> print(re.match(r"(?i:ß)", "SS"))
None
```