### PR TITLE
Deprecated key fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 license_file = LICENSE.txt
 
 [bdist_wheel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ description_file = README.md
 license_file = LICENSE.txt
 
 [bdist_wheel]
-python-tag = py37
+python_tag = py37


### PR DESCRIPTION
Fixes error when adding packages with newer setuptools versions

`setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.`